### PR TITLE
Add vue.js support

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -103,7 +103,7 @@ define((require, exports, module) => {
   contextMenu.addMenuItem(AUTOFIX_COMMAND_ID);
 
   // register a linter with CodeInspection
-  ['javascript', 'jsx', 'typescript', 'tsx'].forEach((langId) => {
+  ['javascript', 'jsx', 'typescript', 'tsx', 'vue'].forEach((langId) => {
     CodeInspection.register(langId, {
       name: LINTER_NAME,
       scanFile: handleLintSync,


### PR DESCRIPTION
I installed https://github.com/pandao/brackets-vue to add syntax highlighting and with this change I see now eslint errors.
I tryed to use an "universal linter" via `CodeInspection.register("*", ...` but I started to see error also in markdown code.
@zaggino could you help me to merge this and create a new release? I don't know how to manage it.